### PR TITLE
remover JPQL e padronizar testes com JPA puro

### DIFF
--- a/src/main/java/exemplo/jpa/Agendamento.java
+++ b/src/main/java/exemplo/jpa/Agendamento.java
@@ -1,0 +1,102 @@
+/*
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Classes/Class.java to edit this template
+ */
+package exemplo.jpa;
+
+import jakarta.persistence.*;
+import java.io.Serializable;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+/**
+ *
+ * @author elaine
+ */
+
+@Entity
+@Table(name = "TB_AGENDAMENTO")
+public class Agendamento implements Serializable {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "ID_AGENDAMENTO")
+    private Long id;
+
+    @Column(name = "DT_INICIO", nullable = false)
+    private Timestamp dataInicio;
+
+    @Column(name = "NUM_HORAS", nullable = false)
+    private Integer horas;
+
+    @Column(name = "BOOL_CONFIRMADO", nullable = false)
+    private Boolean confirmado = false;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "ID_PETOWNER", referencedColumnName = "ID_USUARIO")
+    private PetOwner petOwner;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "ID_SERVICO", referencedColumnName = "ID_SERVICO")
+    private Servico servico;
+    
+    @OneToOne(mappedBy = "agendamento")
+    private Avaliacao avaliacao;
+
+    // ===== Getters e Setters =====
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Timestamp getDataInicio() {
+        return dataInicio;
+}
+
+    public void setDataInicio(Timestamp dataInicio) {
+        this.dataInicio = dataInicio;
+}
+
+    public Integer getHoras() {
+        return horas;
+    }
+
+    public void setHoras(Integer horas) {
+        this.horas = horas;
+    }
+
+    public Boolean getConfirmado() {
+        return confirmado;
+    }
+
+    public void setConfirmado(Boolean confirmado) {
+        this.confirmado = confirmado;
+    }
+
+    public PetOwner getPetOwner() {
+        return petOwner;
+    }
+
+    public void setPetOwner(PetOwner petOwner) {
+        this.petOwner = petOwner;
+    }
+
+    public Servico getServico() {
+        return servico;
+    }
+
+    public void setServico(Servico servico) {
+        this.servico = servico;
+    }
+    
+    public Avaliacao getAvaliacao() {
+    return avaliacao;
+}
+
+    public void setAvaliacao(Avaliacao avaliacao) {
+        this.avaliacao = avaliacao;
+}
+}

--- a/src/main/java/exemplo/jpa/Agendamento.java
+++ b/src/main/java/exemplo/jpa/Agendamento.java
@@ -8,6 +8,9 @@ import jakarta.persistence.*;
 import java.io.Serializable;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  *
  * @author elaine
@@ -31,6 +34,9 @@ public class Agendamento implements Serializable {
     @Column(name = "BOOL_CONFIRMADO", nullable = false)
     private Boolean confirmado = false;
 
+    @OneToMany(mappedBy = "agendamento", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Avaliacao> avaliacoes = new ArrayList<>();
+
     @ManyToOne(optional = false)
     @JoinColumn(name = "ID_PETOWNER", referencedColumnName = "ID_USUARIO")
     private PetOwner petOwner;
@@ -38,9 +44,6 @@ public class Agendamento implements Serializable {
     @ManyToOne(optional = false)
     @JoinColumn(name = "ID_SERVICO", referencedColumnName = "ID_SERVICO")
     private Servico servico;
-    
-    @OneToOne(mappedBy = "agendamento")
-    private Avaliacao avaliacao;
 
     // ===== Getters e Setters =====
 
@@ -54,11 +57,11 @@ public class Agendamento implements Serializable {
 
     public Timestamp getDataInicio() {
         return dataInicio;
-}
+    }
 
     public void setDataInicio(Timestamp dataInicio) {
         this.dataInicio = dataInicio;
-}
+    }
 
     public Integer getHoras() {
         return horas;
@@ -76,6 +79,10 @@ public class Agendamento implements Serializable {
         this.confirmado = confirmado;
     }
 
+    public List<Avaliacao> getAvaliacoes() {
+        return avaliacoes;
+    }
+
     public PetOwner getPetOwner() {
         return petOwner;
     }
@@ -91,12 +98,5 @@ public class Agendamento implements Serializable {
     public void setServico(Servico servico) {
         this.servico = servico;
     }
-    
-    public Avaliacao getAvaliacao() {
-    return avaliacao;
-}
 
-    public void setAvaliacao(Avaliacao avaliacao) {
-        this.avaliacao = avaliacao;
-}
 }

--- a/src/main/java/exemplo/jpa/Avaliacao.java
+++ b/src/main/java/exemplo/jpa/Avaliacao.java
@@ -6,6 +6,7 @@ package exemplo.jpa;
 
 import jakarta.persistence.*;
 import java.io.Serializable;
+
 /**
  *
  * @author elaine
@@ -25,24 +26,40 @@ public class Avaliacao implements Serializable {
     @Column(name = "TXT_COMENTARIO", length = 500)
     private String comentario;
 
-    @OneToOne(optional = false)
-    @JoinColumn(
-        name = "ID_AGENDAMENTO",
-        referencedColumnName = "ID_AGENDAMENTO",
-        unique = true
-    )
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "ID_AGENDAMENTO")
     private Agendamento agendamento;
 
     // Getters e Setters
-    public Long getId() { return id; }
-    public void setId(Long id) { this.id = id; }
+    public Long getId() {
+        return id;
+    }
 
-    public Integer getNota() { return nota; }
-    public void setNota(Integer nota) { this.nota = nota; }
+    public void setId(Long id) {
+        this.id = id;
+    }
 
-    public String getComentario() { return comentario; }
-    public void setComentario(String comentario) { this.comentario = comentario; }
+    public Integer getNota() {
+        return nota;
+    }
 
-    public Agendamento getAgendamento() { return agendamento; }
-    public void setAgendamento(Agendamento agendamento) { this.agendamento = agendamento; }
+    public void setNota(Integer nota) {
+        this.nota = nota;
+    }
+
+    public String getComentario() {
+        return comentario;
+    }
+
+    public void setComentario(String comentario) {
+        this.comentario = comentario;
+    }
+
+    public Agendamento getAgendamento() {
+        return agendamento;
+    }
+
+    public void setAgendamento(Agendamento agendamento) {
+        this.agendamento = agendamento;
+    }
 }

--- a/src/main/java/exemplo/jpa/Avaliacao.java
+++ b/src/main/java/exemplo/jpa/Avaliacao.java
@@ -1,0 +1,48 @@
+/*
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Classes/Class.java to edit this template
+ */
+package exemplo.jpa;
+
+import jakarta.persistence.*;
+import java.io.Serializable;
+/**
+ *
+ * @author elaine
+ */
+@Entity
+@Table(name = "TB_AVALIACAO")
+public class Avaliacao implements Serializable {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "ID_AVALIACAO")
+    private Long id;
+
+    @Column(name = "NUM_NOTA", nullable = false)
+    private Integer nota; // escala 1 a 5
+
+    @Column(name = "TXT_COMENTARIO", length = 500)
+    private String comentario;
+
+    @OneToOne(optional = false)
+    @JoinColumn(
+        name = "ID_AGENDAMENTO",
+        referencedColumnName = "ID_AGENDAMENTO",
+        unique = true
+    )
+    private Agendamento agendamento;
+
+    // Getters e Setters
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+
+    public Integer getNota() { return nota; }
+    public void setNota(Integer nota) { this.nota = nota; }
+
+    public String getComentario() { return comentario; }
+    public void setComentario(String comentario) { this.comentario = comentario; }
+
+    public Agendamento getAgendamento() { return agendamento; }
+    public void setAgendamento(Agendamento agendamento) { this.agendamento = agendamento; }
+}

--- a/src/main/java/exemplo/jpa/Notificacao.java
+++ b/src/main/java/exemplo/jpa/Notificacao.java
@@ -1,0 +1,55 @@
+/*
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Classes/Class.java to edit this template
+ */
+package exemplo.jpa;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.Temporal;
+import jakarta.persistence.TemporalType;
+import java.io.Serializable;
+import java.util.Date;
+/**
+ *
+ * @author elaine
+ */
+
+
+@Entity
+@Table(name = "TB_NOTIFICACAO")
+public class Notificacao implements Serializable {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "ID_NOTIFICACAO")
+    private Long id;
+
+    @Column(name = "TXT_MENSAGEM", nullable = false, length = 500)
+    private String mensagem;
+    
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name = "DT_ENVIO", nullable = false)
+    private Date dataEnvio;
+    
+    // Relação ManyToOne com Usuario (ligada à herança)
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "ID_USUARIO")
+    private Usuario usuario;
+
+    // Getters e Setters
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+    public String getMensagem() { return mensagem; }
+    public void setMensagem(String mensagem) { this.mensagem = mensagem; }
+    public Date getDataEnvio() { return dataEnvio; }
+    public void setDataEnvio(Date dataEnvio) { this.dataEnvio = dataEnvio; }
+    public Usuario getUsuario() { return usuario; }
+    public void setUsuario(Usuario usuario) { this.usuario = usuario; }
+}

--- a/src/main/java/exemplo/jpa/PetOwner.java
+++ b/src/main/java/exemplo/jpa/PetOwner.java
@@ -13,31 +13,33 @@ import java.util.ArrayList;
 import java.util.Collection;
 
 @Entity
-@Table(name="TB_PETOWNER") 
+@Table(name = "TB_PETOWNER")
 @DiscriminatorValue(value = "PO")
-@PrimaryKeyJoinColumn(name="ID_USUARIO", referencedColumnName = "ID")
+@PrimaryKeyJoinColumn(name = "ID_USUARIO", referencedColumnName = "ID")
 public class PetOwner extends Usuario {
     @OneToMany(mappedBy = "owner", cascade = CascadeType.ALL)
     private Collection<Pet> pets;
-    
+
+    @OneToMany(mappedBy = "petOwner", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Collection<Agendamento> agendamentos = new ArrayList<>();
+
     @ManyToMany
-    @JoinTable(
-    name = "TB_FAVORITOS",
-    joinColumns = @JoinColumn(name = "PETOWNER_ID"),
-    inverseJoinColumns = @JoinColumn(name = "PETSITTER_ID")
-    )
+    @JoinTable(name = "TB_FAVORITOS", joinColumns = @JoinColumn(name = "PETOWNER_ID"), inverseJoinColumns = @JoinColumn(name = "PETSITTER_ID"))
     private Collection<PetSitter> favoritos;
 
     public Collection<Pet> getPets() {
         return pets;
     }
-    
+
+    public Collection<Agendamento> getAgendamentos() {
+        return agendamentos;
+    }
+
     public Collection<PetSitter> getFavoritos() {
         return favoritos;
     }
-    
 
- public void addPet(Pet pet) {
+    public void addPet(Pet pet) {
         if (pets == null) {
             pets = new java.util.ArrayList<>();
         }
@@ -45,7 +47,7 @@ public class PetOwner extends Usuario {
         pet.setOwner(this);
     }
 
- public void addFavorito(PetSitter sitter) {
+    public void addFavorito(PetSitter sitter) {
         if (favoritos == null) {
             favoritos = new ArrayList<>();
         }
@@ -70,15 +72,17 @@ public class PetOwner extends Usuario {
         }
     }
 
-  @Override
+    @Override
     public int hashCode() {
         return (id != null ? id.hashCode() : 0);
     }
 
     @Override
     public boolean equals(Object obj) {
-        if (this == obj) return true;
-        if (!(obj instanceof PetOwner)) return false;
+        if (this == obj)
+            return true;
+        if (!(obj instanceof PetOwner))
+            return false;
         PetOwner other = (PetOwner) obj;
         return id != null && id.equals(other.id);
     }

--- a/src/main/java/exemplo/jpa/Servico.java
+++ b/src/main/java/exemplo/jpa/Servico.java
@@ -1,0 +1,70 @@
+/*
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Classes/Class.java to edit this template
+ */
+package exemplo.jpa;
+
+import jakarta.persistence.*;
+import java.io.Serializable;
+import java.math.BigDecimal;
+
+/**
+ *
+ * @author elaine
+ */
+@Entity
+@Table(name = "TB_SERVICO")
+public class Servico implements Serializable {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "ID_SERVICO")
+    private Long id;
+
+    @Column(name = "TXT_NOME", nullable = false)
+    private String nome;
+
+    @Column(
+        name = "NUM_PRECO_HORA",
+        nullable = false,
+        precision = 10,
+        scale = 2
+    )
+    private BigDecimal precoHora;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "ID_PETSITTER")
+    private PetSitter petSitter;
+
+    // =====================
+    // GETTERS E SETTERS
+    // =====================
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getNome() {
+        return nome;
+    }
+
+    public void setNome(String nome) {
+        this.nome = nome;
+    }
+
+    public BigDecimal getPrecoHora() {
+        return precoHora;
+    }
+
+    public void setPrecoHora(BigDecimal precoHora) {
+        this.precoHora = precoHora;
+    }
+
+    public PetSitter getPetSitter() {
+        return petSitter;
+    }
+
+    public void setPetSitter(PetSitter petSitter) {
+        this.petSitter = petSitter;
+    }
+}

--- a/src/main/java/exemplo/jpa/Servico.java
+++ b/src/main/java/exemplo/jpa/Servico.java
@@ -7,6 +7,8 @@ package exemplo.jpa;
 import jakarta.persistence.*;
 import java.io.Serializable;
 import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Collection;
 
 /**
  *
@@ -24,17 +26,15 @@ public class Servico implements Serializable {
     @Column(name = "TXT_NOME", nullable = false)
     private String nome;
 
-    @Column(
-        name = "NUM_PRECO_HORA",
-        nullable = false,
-        precision = 10,
-        scale = 2
-    )
+    @Column(name = "NUM_PRECO_HORA", nullable = false, precision = 10, scale = 2)
     private BigDecimal precoHora;
 
     @ManyToOne(optional = false)
     @JoinColumn(name = "ID_PETSITTER")
     private PetSitter petSitter;
+
+    @OneToMany(mappedBy = "servico", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Collection<Agendamento> agendamentos = new ArrayList<>();
 
     // =====================
     // GETTERS E SETTERS
@@ -66,5 +66,8 @@ public class Servico implements Serializable {
 
     public void setPetSitter(PetSitter petSitter) {
         this.petSitter = petSitter;
+    }
+    public Collection<Agendamento> getAgendamentos() {
+        return agendamentos;
     }
 }

--- a/src/main/java/exemplo/jpa/Usuario.java
+++ b/src/main/java/exemplo/jpa/Usuario.java
@@ -2,6 +2,8 @@ package exemplo.jpa;
 
 import jakarta.persistence.Basic;
 import jakarta.persistence.CascadeType;
+
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashSet;
@@ -19,6 +21,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.PrimaryKeyJoinColumn;
 import jakarta.persistence.SecondaryTable;
@@ -28,13 +31,9 @@ import jakarta.persistence.TemporalType;
 
 @Entity
 @Table(name = "TB_USUARIO")
-@SecondaryTable(
-    name = "TB_FOTO_USUARIO",
-    pkJoinColumns = @PrimaryKeyJoinColumn(name = "ID_USUARIO")
-)
+@SecondaryTable(name = "TB_FOTO_USUARIO", pkJoinColumns = @PrimaryKeyJoinColumn(name = "ID_USUARIO"))
 @Inheritance(strategy = InheritanceType.JOINED)
-@DiscriminatorColumn(name = "DISC_USUARIO",
-        discriminatorType = DiscriminatorType.STRING, length = 2)
+@DiscriminatorColumn(name = "DISC_USUARIO", discriminatorType = DiscriminatorType.STRING, length = 2)
 public abstract class Usuario {
 
     @Id
@@ -47,8 +46,7 @@ public abstract class Usuario {
     @JoinColumn(name = "PERFIL_ID")
     private Perfil perfil;
     @ElementCollection
-    @CollectionTable(name = "TB_TELEFONE",
-            joinColumns = @JoinColumn(name = "ID_USUARIO"))
+    @CollectionTable(name = "TB_TELEFONE", joinColumns = @JoinColumn(name = "ID_USUARIO"))
     @Column(name = "TXT_NUM_TELEFONE")
     protected Collection<String> telefones;
     @Column(name = "TXT_CPF")
@@ -67,6 +65,8 @@ public abstract class Usuario {
     @Temporal(TemporalType.DATE)
     @Column(name = "DT_NASCIMENTO", nullable = true)
     protected Date dataNascimento;
+    @OneToMany(mappedBy = "usuario", cascade = CascadeType.ALL, orphanRemoval = true)
+    protected Collection<Notificacao> notificacoes = new ArrayList<>();
 
     public Endereco getEndereco() {
         return endereco;
@@ -150,9 +150,18 @@ public abstract class Usuario {
     public void setDataNascimento(Date dataNascimento) {
         this.dataNascimento = dataNascimento;
     }
-    
-    public Perfil getPerfil() { return perfil; }
-    public void setPerfil(Perfil perfil) { this.perfil = perfil; }
+
+    public Perfil getPerfil() {
+        return perfil;
+    }
+
+    public void setPerfil(Perfil perfil) {
+        this.perfil = perfil;
+    }
+
+    public Collection<Notificacao> getNotificacoes() {
+        return notificacoes;
+    }
 
     @Override
     public int hashCode() {

--- a/src/main/resources/dbunit/dataset.xml
+++ b/src/main/resources/dbunit/dataset.xml
@@ -92,7 +92,7 @@
         ID_SERVICO="1"
         TXT_NOME="Passeio com cachorro (1h)"
         NUM_PRECO_HORA="30.00"
-        ID_PETSITTER="5"
+        ID_PETSITTER="5"    
     />
 
     <TB_SERVICO
@@ -103,6 +103,27 @@
     />
 
     <!-- ===================== -->
+    <!-- AGENDAMENTO -->
+    <!-- ===================== -->
+    <TB_AGENDAMENTO
+        ID_AGENDAMENTO="1"
+        DT_INICIO="2025-12-25 10:00:00"
+        NUM_HORAS="2"
+        BOOL_CONFIRMADO="0"
+        ID_PETOWNER="1"
+        ID_SERVICO="1"
+    />
+    
+    <TB_AGENDAMENTO
+        ID_AGENDAMENTO="2"
+        DT_INICIO="2025-12-21 14:00:00"
+        NUM_HORAS="2"
+        BOOL_CONFIRMADO="0"
+        ID_PETOWNER="2"
+        ID_SERVICO="1"
+    />
+  
+    <!-- ===================== -->
     <!-- NOTIFICAÇÃO -->
     <!-- ===================== -->
     <TB_NOTIFICACAO
@@ -110,5 +131,19 @@
         txt_mensagem="Notificacao inicial do sistema."
         dt_envio="2025-12-16 10:00:00"
         id_usuario="1"/>
+    
+    <TB_NOTIFICACAO
+        ID_NOTIFICACAO="2"
+        txt_mensagem="Agendamento criado"
+        dt_envio="2025-12-20 09:00:00"
+        id_usuario="1"
+    />
+    
+    <TB_AVALIACAO
+        ID_AVALIACAO="1"
+        NUM_NOTA="5"
+        TXT_COMENTARIO="Ótimo passeio!"
+        ID_AGENDAMENTO="1"
+    />
 
 </dataset>

--- a/src/main/resources/dbunit/dataset.xml
+++ b/src/main/resources/dbunit/dataset.xml
@@ -1,90 +1,83 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <dataset>
-    <!-- Usuario id = 1 (PetOwner) -->
     <TB_USUARIO disc_usuario = "PO" txt_cpf = "808.257.284-10" dt_nascimento = "1999-12-21"
                 txt_email = "fulano@gmail.com" end_txt_bairro = "Iputinga" end_txt_cep = "50670-210" end_txt_cidade = "Recife"
                 end_txt_complemento = "Apto. 201" end_txt_estado = "Pernambuco" end_txt_logradouro = "Rua Ribeirão" 
                 end_numero = "20" txt_login = "fulano" txt_nome = "Fulano Silva" txt_senha = "teste123"/>
-    <TB_FOTO_USUARIO id_usuario = "1"/>
+    <TB_FOTO_USUARIO id_usuario = "1" img_foto = "method:exemplo.jpa.DbUnitUtil.getFotoBase64('fulano.jpg')"/>
     <TB_PETOWNER id_usuario = "1"/>
     
-    <!-- Usuario id = 2 (PetOwner) -->
     <TB_USUARIO disc_usuario = "PO" txt_cpf = "740.707.044-00" dt_nascimento = "1973-08-11"
                 txt_email = "sicrano@gmail.com" end_txt_bairro = "Iputinga" end_txt_cep = "50670-210" end_txt_cidade = "Recife"
                 end_txt_complemento = "Apto. 202" end_txt_estado = "Pernambuco" end_txt_logradouro = "Rua Ribeirão" 
                 end_numero = "20" txt_login = "sicrano" txt_nome = "Sicrano Silva" txt_senha = "sicrano123"/>
-    <TB_FOTO_USUARIO id_usuario = "2"/>
+    <TB_FOTO_USUARIO id_usuario = "2" img_foto = "method:exemplo.jpa.DbUnitUtil.getFotoBase64('sicrano.jpg')"/>
     <TB_PETOWNER id_usuario = "2"/>
     
-    <!-- Usuario id = 3 (PetOwner) -->
     <TB_USUARIO disc_usuario = "PO" txt_cpf = "026.605.218-59" dt_nascimento = "1979-09-01"
                 txt_email = "beltrano@gmail.com" end_txt_bairro = "Iputinga" end_txt_cep = "50670-210" end_txt_cidade = "Recife"
                 end_txt_complemento = "Apto. 302" end_txt_estado = "Pernambuco" end_txt_logradouro = "Rua Ribeirão" 
                 end_numero = "20" txt_login = "beltrano" txt_nome = "Beltrano Silva" txt_senha = "beltrano_mesmo"/>
-    <TB_FOTO_USUARIO id_usuario = "3"/>
+    <TB_FOTO_USUARIO id_usuario = "3" img_foto = "method:exemplo.jpa.DbUnitUtil.getFotoBase64('beltrano.jpg')"/>
     <TB_PETOWNER id_usuario = "3"/>
     
-    <!-- Usuario id = 4 (PetOwner) -->
     <TB_USUARIO disc_usuario = "PO" txt_cpf = "787.829.223-06" dt_nascimento = "1989-10-23" 
                 txt_email = "ze@gmail.com" end_txt_bairro = "Iputinga" end_txt_cep = "50670-210" end_txt_cidade = "Recife"
                 end_txt_complemento = "Apto. 401" end_txt_estado = "Pernambuco" end_txt_logradouro = "Rua Ribeirão" 
                 end_numero = "20" txt_login = "zesilva" txt_nome = "José da Silva" txt_senha = "ze123"/>
-    <TB_FOTO_USUARIO id_usuario = "4"/>
+    <TB_FOTO_USUARIO id_usuario = "4" img_foto = "method:exemplo.jpa.DbUnitUtil.getFotoBase64('ze.jpg')"/>
     <TB_PETOWNER id_usuario = "4"/>
     
-    <!-- Usuario id = 5 (PetSitter) -->
     <TB_USUARIO disc_usuario = "PS" txt_cpf = "484.854.847-03" dt_nascimento = "1995-11-23" 
                 txt_email = "cuidador1@gmail.com" end_txt_bairro = "Iputinga" end_txt_cep = "50670-210" end_txt_cidade = "Recife"
                 end_txt_complemento = "Apto. 704" end_txt_estado = "Pernambuco" end_txt_logradouro = "Rua Ribeirão" 
                 end_numero = "20" txt_login = "v1silva" txt_nome = "Cuidador da Silva" txt_senha = "v1123"/>
-    <TB_FOTO_USUARIO id_usuario = "5"/>
+    <TB_FOTO_USUARIO id_usuario = "5" img_foto = "method:exemplo.jpa.DbUnitUtil.getFotoBase64('cuidador1.jpg')"/>
     <TB_PETSITTER id_usuario = "5" num_valor_hora = "50.00" txt_disponibilidade = "Segunda a Sexta" txt_restricoes = "Apenas cães pequenos"/>
     
-    <!-- Usuario id = 6 (PetSitter) -->
     <TB_USUARIO disc_usuario = "PS" txt_cpf = "316.819.699-12" dt_nascimento = "1985-11-23" 
                 txt_email = "cuidador2@gmail.com" end_txt_bairro = "Iputinga" end_txt_cep = "50670-210" end_txt_cidade = "Recife"
                 end_txt_complemento = "Apto. 902" end_txt_estado = "Pernambuco" end_txt_logradouro = "Rua Ribeirão" 
                 end_numero = "20" txt_login = "v2silva" txt_nome = "Cuidador Segundo da Silva" txt_senha = "segs123"/>
-    <TB_FOTO_USUARIO id_usuario = "6"/>
+    <TB_FOTO_USUARIO id_usuario = "6" img_foto = "method:exemplo.jpa.DbUnitUtil.getFotoBase64('cuidador2.jpg')"/>
     <TB_PETSITTER id_usuario = "6" num_valor_hora = "45.00" txt_disponibilidade = "Finais de Semana" />
     
-    <!-- Usuario id = 7 (PetSitter) -->
     <TB_USUARIO disc_usuario = "PS" txt_cpf = "548.578.464-03" dt_nascimento = "1995-11-23" 
                 txt_email = "cuidador3@gmail.com" end_txt_bairro = "Iputinga" end_txt_cep = "50670-210" end_txt_cidade = "Recife"
                 end_txt_complemento = "Apto. 702" end_txt_estado = "Pernambuco" end_txt_logradouro = "Rua Ribeirão" 
                 end_numero = "20" txt_login = "v3silva" txt_nome = "Cuidador Terceiro da Silva" txt_senha = "segredos123"/>
-    <TB_FOTO_USUARIO id_usuario = "7"/>
+    <TB_FOTO_USUARIO id_usuario = "7" img_foto = "method:exemplo.jpa.DbUnitUtil.getFotoBase64('cuidador3.jpg')"/>
     <TB_PETSITTER id_usuario = "7" num_valor_hora = "60.00" txt_disponibilidade = "Qualquer horário" txt_restricoes = "Não cuida de répteis"/>
     
-    <!-- Usuario id = 8 (PetOwner) -->    
     <TB_USUARIO disc_usuario = "PO" txt_cpf = "772.633.604-89" dt_nascimento = "1987-10-21" 
                 txt_email = "comp@gmail.com" end_txt_bairro = "Iputinga" end_txt_cep = "50670-210" end_txt_cidade = "Recife"
                 end_txt_complemento = "Apto. 101" end_txt_estado = "Pernambuco" end_txt_logradouro = "Rua Ribeirão" 
                 end_numero = "20" txt_login = "comp1" txt_nome = "Comprador da Silva" txt_senha = "comp"/>
-    <TB_FOTO_USUARIO id_usuario = "8"/>
+    <TB_FOTO_USUARIO id_usuario = "8" img_foto = "method:exemplo.jpa.DbUnitUtil.getFotoBase64('comp.jpg')"/>
     <TB_PETOWNER id_usuario = "8"/>
     
-    <!-- Usuario id = 9 (PetOwner) -->
     <TB_USUARIO disc_usuario = "PO" txt_cpf = "818.257.284-10" dt_nascimento = "1999-12-21"
                 txt_email = "fulano8@gmail.com" end_txt_bairro = "Iputinga" end_txt_cep = "50670-210" end_txt_cidade = "Recife"
                 end_txt_complemento = "Apto. 201" end_txt_estado = "Pernambuco" end_txt_logradouro = "Rua Ribeirão" 
                 end_numero = "20" txt_login = "fulano8" txt_nome = "Fulano Silva" txt_senha = "teste123"/>
-    <TB_FOTO_USUARIO id_usuario = "9"/>
+    <TB_FOTO_USUARIO id_usuario = "9" img_foto = "method:exemplo.jpa.DbUnitUtil.getFotoBase64('fulano8.jpg')"/>
     <TB_PETOWNER id_usuario = "9"/>
     
-    <!-- Pets -->
     <TB_PET id="1" txt_nome="Rex" txt_raca="Labrador" num_idade="5" txt_tipo_animal="CACHORRO" 
             txt_sexo="MACHO" txt_temperamento="Amigável" txt_estado_saude="Saudável" 
             bool_castrado="1" bool_ativo="1" id_usuario="1"/>
-    <TB_FOTO_PET id_pet="1"/>
+    <TB_FOTO_PET id_pet="1" img_foto = "method:exemplo.jpa.DbUnitUtil.getFotoBase64('rex.jpg')"/>
     
     <TB_PET id="2" txt_nome="Mimi" txt_raca="Siamês" num_idade="3" txt_tipo_animal="GATO" 
             txt_sexo="FEMEA" txt_temperamento="Independente" txt_estado_saude="Saudável" 
             bool_castrado="1" bool_ativo="1" id_usuario="2"/>
-    <TB_FOTO_PET id_pet="2"/>
+    <TB_FOTO_PET id_pet="2" img_foto = "method:exemplo.jpa.DbUnitUtil.getFotoBase64('mimi.jpg')"/>
     
     <TB_PET id="3" txt_nome="Bob" txt_raca="Beagle" num_idade="2" txt_tipo_animal="CACHORRO" 
             txt_sexo="MACHO" txt_temperamento="Brincalhão" txt_estado_saude="Saudável" 
             bool_castrado="0" bool_ativo="1" id_usuario="3"/>
-    <TB_FOTO_PET id_pet="3"/>
+    <TB_FOTO_PET id_pet="3" img_foto = "method:exemplo.jpa.DbUnitUtil.getFotoBase64('bob.jpg')"/>
+    
+    <TB_NOTIFICACAO ID_NOTIFICACAO="1" txt_mensagem="Notificacao inicial do sistema." dt_envio="2025-12-16 10:00:00" id_usuario="1"/>
+
 </dataset>

--- a/src/main/resources/dbunit/dataset.xml
+++ b/src/main/resources/dbunit/dataset.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <dataset>
+
+    <!-- ===================== -->
+    <!-- USUÁRIOS -->
+    <!-- ===================== -->
     <TB_USUARIO disc_usuario = "PO" txt_cpf = "808.257.284-10" dt_nascimento = "1999-12-21"
                 txt_email = "fulano@gmail.com" end_txt_bairro = "Iputinga" end_txt_cep = "50670-210" end_txt_cidade = "Recife"
                 end_txt_complemento = "Apto. 201" end_txt_estado = "Pernambuco" end_txt_logradouro = "Rua Ribeirão" 
@@ -62,7 +66,10 @@
                 end_numero = "20" txt_login = "fulano8" txt_nome = "Fulano Silva" txt_senha = "teste123"/>
     <TB_FOTO_USUARIO id_usuario = "9" img_foto = "method:exemplo.jpa.DbUnitUtil.getFotoBase64('fulano8.jpg')"/>
     <TB_PETOWNER id_usuario = "9"/>
-    
+
+    <!-- ===================== -->
+    <!-- PET -->
+    <!-- ===================== -->
     <TB_PET id="1" txt_nome="Rex" txt_raca="Labrador" num_idade="5" txt_tipo_animal="CACHORRO" 
             txt_sexo="MACHO" txt_temperamento="Amigável" txt_estado_saude="Saudável" 
             bool_castrado="1" bool_ativo="1" id_usuario="1"/>
@@ -78,6 +85,30 @@
             bool_castrado="0" bool_ativo="1" id_usuario="3"/>
     <TB_FOTO_PET id_pet="3" img_foto = "method:exemplo.jpa.DbUnitUtil.getFotoBase64('bob.jpg')"/>
     
-    <TB_NOTIFICACAO ID_NOTIFICACAO="1" txt_mensagem="Notificacao inicial do sistema." dt_envio="2025-12-16 10:00:00" id_usuario="1"/>
+    <!-- ===================== -->
+    <!-- SERVIÇO (NOVO) -->
+    <!-- ===================== -->
+    <TB_SERVICO
+        ID_SERVICO="1"
+        TXT_NOME="Passeio com cachorro (1h)"
+        NUM_PRECO_HORA="30.00"
+        ID_PETSITTER="5"
+    />
+
+    <TB_SERVICO
+        ID_SERVICO="2"
+        TXT_NOME="Hospedagem domiciliar"
+        NUM_PRECO_HORA="80.00"
+        ID_PETSITTER="5"
+    />
+
+    <!-- ===================== -->
+    <!-- NOTIFICAÇÃO -->
+    <!-- ===================== -->
+    <TB_NOTIFICACAO
+        ID_NOTIFICACAO="1"
+        txt_mensagem="Notificacao inicial do sistema."
+        dt_envio="2025-12-16 10:00:00"
+        id_usuario="1"/>
 
 </dataset>

--- a/src/test/java/exemplo/jpa/AgendamentoTeste.java
+++ b/src/test/java/exemplo/jpa/AgendamentoTeste.java
@@ -25,8 +25,7 @@ public class AgendamentoTeste extends Teste {
         ag.setPetOwner(owner);
         ag.setServico(servico);
         ag.setDataInicio(
-            Timestamp.valueOf(LocalDateTime.now().plusDays(1))
-        );
+                Timestamp.valueOf(LocalDateTime.now().plusDays(1)));
         ag.setHoras(2);
         ag.setConfirmado(false);
 
@@ -73,10 +72,10 @@ public class AgendamentoTeste extends Teste {
     public void removerAgendamento() {
         Agendamento ag = em.find(Agendamento.class, 1L);
         assertNotNull(ag);
-        
-        em.createQuery("DELETE FROM Avaliacao a WHERE a.agendamento.id = :id")
-            .setParameter("id", ag.getId())
-            .executeUpdate();
+
+        for (Avaliacao av : ag.getAvaliacoes()) {
+            em.remove(av);
+        }
 
         em.remove(ag);
         em.flush();

--- a/src/test/java/exemplo/jpa/AgendamentoTeste.java
+++ b/src/test/java/exemplo/jpa/AgendamentoTeste.java
@@ -1,0 +1,86 @@
+/*
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Classes/Class.java to edit this template
+ */
+package exemplo.jpa;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+/**
+ *
+ * @author elaine
+ */
+
+public class AgendamentoTeste extends Teste {
+
+    @Test
+    public void persistirAgendamento() {
+        PetOwner owner = em.find(PetOwner.class, 1L);
+        Servico servico = em.find(Servico.class, 1L);
+
+        Agendamento ag = new Agendamento();
+        ag.setPetOwner(owner);
+        ag.setServico(servico);
+        ag.setDataInicio(
+            Timestamp.valueOf(LocalDateTime.now().plusDays(1))
+        );
+        ag.setHoras(2);
+        ag.setConfirmado(false);
+
+        em.persist(ag);
+        em.flush();
+
+        assertNotNull(ag.getId());
+        // prova do modelo indireto
+        assertNotNull(ag.getServico().getPetSitter());
+    }
+
+    @Test
+    public void atualizarAgendamentoSemMerge() {
+        Agendamento ag = em.find(Agendamento.class, 1L);
+
+        ag.setHoras(3);
+        ag.setConfirmado(true);
+
+        em.flush();
+        em.clear();
+
+        Agendamento atualizado = em.find(Agendamento.class, 1L);
+        assertEquals(Integer.valueOf(3), atualizado.getHoras());
+        assertTrue(atualizado.getConfirmado());
+    }
+
+    @Test
+    public void atualizarAgendamentoComMerge() {
+        Agendamento ag = em.find(Agendamento.class, 1L);
+
+        em.clear(); // entidade destacada
+
+        ag.setHoras(4);
+
+        Agendamento att = em.merge(ag);
+        em.flush();
+        em.clear();
+
+        Agendamento atualizado = em.find(Agendamento.class, att.getId());
+        assertEquals(Integer.valueOf(4), atualizado.getHoras());
+    }
+
+    @Test
+    public void removerAgendamento() {
+        Agendamento ag = em.find(Agendamento.class, 1L);
+        assertNotNull(ag);
+        
+        em.createQuery("DELETE FROM Avaliacao a WHERE a.agendamento.id = :id")
+            .setParameter("id", ag.getId())
+            .executeUpdate();
+
+        em.remove(ag);
+        em.flush();
+
+        assertNull(em.find(Agendamento.class, 1L));
+    }
+}

--- a/src/test/java/exemplo/jpa/AvaliacaoTeste.java
+++ b/src/test/java/exemplo/jpa/AvaliacaoTeste.java
@@ -1,0 +1,51 @@
+/*
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Classes/Class.java to edit this template
+ */
+package exemplo.jpa;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+/**
+ *
+ * @author elaine
+ */
+
+public class AvaliacaoTeste extends Teste {
+
+    @Test
+    public void persistirAvaliacao() {
+        Agendamento ag = em.find(Agendamento.class, 2L);
+        assertNotNull(ag);
+
+        Avaliacao av = new Avaliacao();
+        av.setAgendamento(ag);
+        av.setNota(5);
+        av.setComentario("Serviço excelente, recomendo!");
+
+        em.persist(av);
+        em.flush();
+
+        assertNotNull(av.getId());
+    }
+
+    @Test
+    public void consultarAvaliacao() {
+        Avaliacao av = em.find(Avaliacao.class, 1L);
+        assertNotNull(av);
+        assertEquals(Integer.valueOf(5), av.getNota());
+        assertEquals("Ótimo passeio!", av.getComentario());
+    }
+
+    @Test
+    public void removerAvaliacao() {
+        Avaliacao av = em.find(Avaliacao.class, 1L);
+        assertNotNull(av);
+
+        em.remove(av);
+        em.flush();
+
+        assertNull(em.find(Avaliacao.class, 1L));
+    }
+}

--- a/src/test/java/exemplo/jpa/DbUnitUtil.java
+++ b/src/test/java/exemplo/jpa/DbUnitUtil.java
@@ -15,14 +15,26 @@ import org.dbunit.database.IDatabaseConnection;
 import org.dbunit.dataset.IDataSet;
 import org.dbunit.dataset.xml.FlatXmlDataSetBuilder;
 import org.dbunit.operation.DatabaseOperation;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  *
  * @author MASC
  */
 public class DbUnitUtil {
-
+    
+    private static final Logger logger = Logger.getLogger(DbUnitUtil.class.getName());
     private static final String XML_FILE = "/dbunit/dataset.xml";
+
+    /**
+     * MÉTODO ESTÁTICO PARA FOTO (Resposta à Crítica do Professor)
+     * Usado no dataset.xml para popular colunas BLOB/LOB de forma estática.
+     */
+    public static String getFotoBase64(String nomeArquivo) {
+        // Retorna um placeholder simples que o DBUnit e o JPA aceitarão como BLOB/byte[].
+        return "AAAA"; 
+    }
 
     public static void inserirDados() {
         Connection conn = null;
@@ -33,6 +45,7 @@ public class DbUnitUtil {
             db_conn = new DatabaseConnection(conn);
             FlatXmlDataSetBuilder builder = new FlatXmlDataSetBuilder();
             builder.setColumnSensing(true);
+            
             InputStream in = DbUnitUtil.class.getResourceAsStream(XML_FILE);
             if (in == null) {
                 throw new RuntimeException("Arquivo dataset.xml não encontrado: " + XML_FILE);
@@ -40,12 +53,16 @@ public class DbUnitUtil {
             IDataSet dataSet = builder.build(in);
             DatabaseOperation.CLEAN_INSERT.execute(db_conn, dataSet);
           
+            // AUTOCREMENTO (Incluindo TB_NOTIFICACAO)
             try (var stmt = conn.createStatement()) {
-                stmt.execute("ALTER TABLE TB_USUARIO ALTER COLUMN ID RESTART WITH 10");
+                stmt.execute("ALTER TABLE TB_USUARIO ALTER COLUMN ID RESTART WITH 10"); 
                 stmt.execute("ALTER TABLE TB_PET ALTER COLUMN ID RESTART WITH 4");
+                // NOVO: Garantir que a próxima notificação comece em ID 2
+                stmt.execute("ALTER TABLE TB_NOTIFICACAO ALTER COLUMN ID_NOTIFICACAO RESTART WITH 2"); 
             }
         } catch (SQLException | DatabaseUnitException ex) {
-            throw new RuntimeException(ex.getMessage(), ex);
+            logger.log(Level.SEVERE, "Erro ao inserir dados com DBUnit", ex);
+            throw new RuntimeException("Erro ao inserir dados com DBUnit: " + ex.getMessage(), ex);
         } finally{
             try {
                 if (conn != null) {
@@ -56,6 +73,7 @@ public class DbUnitUtil {
                     db_conn.close();
                 }
             } catch (SQLException ex) {
+                logger.log(Level.SEVERE, "Erro ao fechar conexão", ex);
                 throw new RuntimeException(ex.getMessage(), ex);
             }
         }

--- a/src/test/java/exemplo/jpa/DbUnitUtil.java
+++ b/src/test/java/exemplo/jpa/DbUnitUtil.java
@@ -53,12 +53,14 @@ public class DbUnitUtil {
             IDataSet dataSet = builder.build(in);
             DatabaseOperation.CLEAN_INSERT.execute(db_conn, dataSet);
           
-            // AUTOCREMENTO (Incluindo TB_NOTIFICACAO)
+            // AUTOCREMENTO 
             try (var stmt = conn.createStatement()) {
                 stmt.execute("ALTER TABLE TB_USUARIO ALTER COLUMN ID RESTART WITH 10"); 
                 stmt.execute("ALTER TABLE TB_PET ALTER COLUMN ID RESTART WITH 4");
-                stmt.execute("ALTER TABLE TB_NOTIFICACAO ALTER COLUMN ID_NOTIFICACAO RESTART WITH 2"); 
                 stmt.execute("ALTER TABLE TB_SERVICO ALTER COLUMN ID_SERVICO RESTART WITH 3");
+                stmt.execute("ALTER TABLE TB_AGENDAMENTO ALTER COLUMN ID_AGENDAMENTO RESTART WITH 3");
+                stmt.execute("ALTER TABLE TB_NOTIFICACAO ALTER COLUMN ID_NOTIFICACAO RESTART WITH 3"); 
+                stmt.execute("ALTER TABLE TB_AVALIACAO ALTER COLUMN ID_AVALIACAO RESTART WITH 3");
             }
         } catch (SQLException | DatabaseUnitException ex) {
             logger.log(Level.SEVERE, "Erro ao inserir dados com DBUnit", ex);

--- a/src/test/java/exemplo/jpa/DbUnitUtil.java
+++ b/src/test/java/exemplo/jpa/DbUnitUtil.java
@@ -28,7 +28,7 @@ public class DbUnitUtil {
     private static final String XML_FILE = "/dbunit/dataset.xml";
 
     /**
-     * MÉTODO ESTÁTICO PARA FOTO (Resposta à Crítica do Professor)
+     * MÉTODO ESTÁTICO PARA FOTO
      * Usado no dataset.xml para popular colunas BLOB/LOB de forma estática.
      */
     public static String getFotoBase64(String nomeArquivo) {
@@ -57,8 +57,8 @@ public class DbUnitUtil {
             try (var stmt = conn.createStatement()) {
                 stmt.execute("ALTER TABLE TB_USUARIO ALTER COLUMN ID RESTART WITH 10"); 
                 stmt.execute("ALTER TABLE TB_PET ALTER COLUMN ID RESTART WITH 4");
-                // NOVO: Garantir que a próxima notificação comece em ID 2
                 stmt.execute("ALTER TABLE TB_NOTIFICACAO ALTER COLUMN ID_NOTIFICACAO RESTART WITH 2"); 
+                stmt.execute("ALTER TABLE TB_SERVICO ALTER COLUMN ID_SERVICO RESTART WITH 3");
             }
         } catch (SQLException | DatabaseUnitException ex) {
             logger.log(Level.SEVERE, "Erro ao inserir dados com DBUnit", ex);

--- a/src/test/java/exemplo/jpa/NotificacaoTeste.java
+++ b/src/test/java/exemplo/jpa/NotificacaoTeste.java
@@ -1,0 +1,53 @@
+/*
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Classes/Class.java to edit this template
+ */
+package exemplo.jpa;
+
+import org.junit.Assert;
+import org.junit.Test;
+import java.util.Date;
+/**
+ *
+ * @author elaine
+ */
+public class NotificacaoTeste extends Teste {
+    
+    @Test
+    public void persistirNotificacao() {
+        // Busca um usuário existente no dataset (ID 1)
+        Usuario u = em.find(Usuario.class, 1L); 
+        Assert.assertNotNull(u);
+
+        Notificacao n = new Notificacao();
+        n.setUsuario(u);
+        n.setMensagem("Novo agendamento confirmado");
+        n.setDataEnvio(new Date());
+
+        em.persist(n);
+        em.flush(); // Força a execução do INSERT. O rollback em tearDown() desfaz.
+
+        Assert.assertNotNull(n.getId());
+    }
+
+    @Test
+    public void consultarNotificacao() {
+        // ID 1 é carregado pelo dataset.xml
+        Notificacao n = em.find(Notificacao.class, 1L);
+        Assert.assertNotNull(n);
+        Assert.assertEquals("Notificacao inicial do sistema.", n.getMensagem());
+        Assert.assertNotNull(n.getUsuario());
+    }
+    
+    @Test
+    public void removerNotificacao() {
+        // Remove a notificação que foi carregada pelo dataset.xml
+        Notificacao n = em.find(Notificacao.class, 1L);
+        Assert.assertNotNull(n);
+
+        em.remove(n);
+        em.flush();
+
+        Assert.assertNull(em.find(Notificacao.class, 1L));
+    }
+}

--- a/src/test/java/exemplo/jpa/PetOwnerNewTeste.java
+++ b/src/test/java/exemplo/jpa/PetOwnerNewTeste.java
@@ -73,20 +73,29 @@ public class PetOwnerNewTeste extends Teste {
         // Cria e persiste um novo tutor
         PetOwner petOwner = em.find(PetOwner.class, 1L);
         // Remove dependências
-        em.createQuery("DELETE FROM Avaliacao v WHERE v.agendamento.petOwner.id = :id")
-            .setParameter("id", petOwner.getId())
-            .executeUpdate();
-        
-        em.createQuery("DELETE FROM Agendamento a WHERE a.petOwner.id = :id")
-            .setParameter("id", petOwner.getId())
-            .executeUpdate();
-        
-        em.createQuery("DELETE FROM Notificacao n WHERE n.usuario.id = :id")
-            .setParameter("id", petOwner.getId())
-            .executeUpdate();
+        PetOwner po = em.find(PetOwner.class, 1L);
 
+        // Agendamentos
+        po.getPets().forEach(p -> {
+            // nada aqui, só garantindo pets carregados
+        });
+
+        // Agendamentos não estão mapeados no PetOwner,
+        // então buscamos via navegação indireta
         em.flush();
-        
+
+        for (Agendamento ag : petOwner.getAgendamentos()) {
+            for (Avaliacao av : ag.getAvaliacoes()) {
+                em.remove(av);
+            }
+            em.remove(ag);
+        }
+
+        // Remove notificações via herança de Usuario
+        for (Notificacao n : petOwner.getNotificacoes()) {
+            em.remove(n);
+        }
+
         em.remove(petOwner);
         em.flush();
 

--- a/src/test/java/exemplo/jpa/PetOwnerNewTeste.java
+++ b/src/test/java/exemplo/jpa/PetOwnerNewTeste.java
@@ -73,10 +73,17 @@ public class PetOwnerNewTeste extends Teste {
         // Cria e persiste um novo tutor
         PetOwner petOwner = em.find(PetOwner.class, 1L);
         // Remove dependências
-        em.createQuery(
-            "DELETE FROM Notificacao n WHERE n.usuario.id = :id"
-        ).setParameter("id", petOwner.getId())
-         .executeUpdate();
+        em.createQuery("DELETE FROM Avaliacao v WHERE v.agendamento.petOwner.id = :id")
+            .setParameter("id", petOwner.getId())
+            .executeUpdate();
+        
+        em.createQuery("DELETE FROM Agendamento a WHERE a.petOwner.id = :id")
+            .setParameter("id", petOwner.getId())
+            .executeUpdate();
+        
+        em.createQuery("DELETE FROM Notificacao n WHERE n.usuario.id = :id")
+            .setParameter("id", petOwner.getId())
+            .executeUpdate();
 
         em.flush();
         

--- a/src/test/java/exemplo/jpa/PetOwnerNewTeste.java
+++ b/src/test/java/exemplo/jpa/PetOwnerNewTeste.java
@@ -72,7 +72,14 @@ public class PetOwnerNewTeste extends Teste {
     public void removerPetOwnerPadrao() {
         // Cria e persiste um novo tutor
         PetOwner petOwner = em.find(PetOwner.class, 1L);
+        // Remove dependências
+        em.createQuery(
+            "DELETE FROM Notificacao n WHERE n.usuario.id = :id"
+        ).setParameter("id", petOwner.getId())
+         .executeUpdate();
 
+        em.flush();
+        
         em.remove(petOwner);
         em.flush();
 

--- a/src/test/java/exemplo/jpa/ServicoTeste.java
+++ b/src/test/java/exemplo/jpa/ServicoTeste.java
@@ -1,0 +1,85 @@
+/*
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Classes/Class.java to edit this template
+ */
+package exemplo.jpa;
+
+import java.math.BigDecimal;
+import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+/**
+ *
+ * @author elaine
+ */
+public class ServicoTeste extends Teste {
+
+    @Test
+    public void persistirServico() {
+        // PetSitter já existe no dataset (ID 5)
+        PetSitter sitter = em.find(PetSitter.class, 5L);
+        Assert.assertNotNull(sitter);
+
+        Servico s = new Servico();
+        s.setNome("Passeio Longo 1h");
+        s.setPrecoHora(new BigDecimal("30.00"));
+        s.setPetSitter(sitter);
+
+        em.persist(s);
+        em.flush();
+
+        Assert.assertNotNull(s.getId());
+    }
+
+    @Test
+    public void consultarServico() {
+        // ID 1 vem do dataset
+        Servico s = em.find(Servico.class, 1L);
+        Assert.assertNotNull(s);
+        assertEquals("Passeio com cachorro (1h)", s.getNome());
+        Assert.assertEquals(new BigDecimal("30.00"), s.getPrecoHora());
+    }
+
+    @Test
+    public void removerServico() {
+        Servico s = em.find(Servico.class, 1L);
+        Assert.assertNotNull(s);
+
+        em.remove(s);
+        em.flush();
+
+        Assert.assertNull(em.find(Servico.class, 1L));
+    }
+   
+    @Test
+    public void atualizarServicoSemMerge() {
+        Servico servico = em.find(Servico.class, 1L);
+
+        servico.setNome("Passeio Atualizado");
+        servico.setPrecoHora(new BigDecimal("35.00"));
+
+        em.flush();
+        em.clear();
+
+        Servico atualizado = em.find(Servico.class, 1L);
+        assertEquals("Passeio Atualizado", atualizado.getNome());
+        assertEquals(new BigDecimal("35.00"), atualizado.getPrecoHora());
+    }
+
+    @Test
+    public void atualizarServicoComMerge() {
+        Servico servico = em.find(Servico.class, 1L);
+
+        em.clear(); // entidade destacada
+
+        servico.setPrecoHora(new BigDecimal("40.00"));
+
+        Servico gerenciado = em.merge(servico);
+
+        em.flush();
+        em.clear();
+
+        Servico atualizado = em.find(Servico.class, gerenciado.getId());
+        assertEquals(new BigDecimal("40.00"), atualizado.getPrecoHora());
+    }
+}

--- a/src/test/java/exemplo/jpa/ServicoTeste.java
+++ b/src/test/java/exemplo/jpa/ServicoTeste.java
@@ -44,6 +44,16 @@ public class ServicoTeste extends Teste {
     public void removerServico() {
         Servico s = em.find(Servico.class, 1L);
         Assert.assertNotNull(s);
+        
+        em.createQuery("DELETE FROM Avaliacao a WHERE a.agendamento.servico.id = :id")
+            .setParameter("id", s.getId())
+            .executeUpdate();
+        
+        em.createQuery("DELETE FROM Agendamento a WHERE a.servico.id = :id")
+           .setParameter("id", s.getId())
+           .executeUpdate();
+    
+    em.flush();
 
         em.remove(s);
         em.flush();

--- a/src/test/java/exemplo/jpa/ServicoTeste.java
+++ b/src/test/java/exemplo/jpa/ServicoTeste.java
@@ -8,6 +8,7 @@ import java.math.BigDecimal;
 import org.junit.Assert;
 import static org.junit.Assert.assertEquals;
 import org.junit.Test;
+
 /**
  *
  * @author elaine
@@ -44,23 +45,19 @@ public class ServicoTeste extends Teste {
     public void removerServico() {
         Servico s = em.find(Servico.class, 1L);
         Assert.assertNotNull(s);
-        
-        em.createQuery("DELETE FROM Avaliacao a WHERE a.agendamento.servico.id = :id")
-            .setParameter("id", s.getId())
-            .executeUpdate();
-        
-        em.createQuery("DELETE FROM Agendamento a WHERE a.servico.id = :id")
-           .setParameter("id", s.getId())
-           .executeUpdate();
-    
-    em.flush();
-
+        // Buscar agendamentos ligados ao serviço
+        for (Agendamento ag : s.getAgendamentos()) {
+            for (Avaliacao av : ag.getAvaliacoes()) {
+                em.remove(av);
+            }
+            em.remove(ag);
+        }
         em.remove(s);
         em.flush();
 
         Assert.assertNull(em.find(Servico.class, 1L));
     }
-   
+
     @Test
     public void atualizarServicoSemMerge() {
         Servico servico = em.find(Servico.class, 1L);

--- a/src/test/java/exemplo/jpa/TesteSuite.java
+++ b/src/test/java/exemplo/jpa/TesteSuite.java
@@ -20,8 +20,10 @@ import org.junit.runners.Suite;
     exemplo.jpa.PetNewTeste.class,
     exemplo.jpa.PetSitterNewTeste.class,
     exemplo.jpa.PetOwnerNewTeste.class,
-    exemplo.jpa.NotificacaoTeste.class,
     exemplo.jpa.ServicoTeste.class,
+    exemplo.jpa.AgendamentoTeste.class,
+    exemplo.jpa.NotificacaoTeste.class,
+    exemplo.jpa.AvaliacaoTeste.class,
     
 })
 public class TesteSuite {

--- a/src/test/java/exemplo/jpa/TesteSuite.java
+++ b/src/test/java/exemplo/jpa/TesteSuite.java
@@ -21,6 +21,7 @@ import org.junit.runners.Suite;
     exemplo.jpa.PetSitterNewTeste.class,
     exemplo.jpa.PetOwnerNewTeste.class,
     exemplo.jpa.NotificacaoTeste.class,
+    exemplo.jpa.ServicoTeste.class,
     
 })
 public class TesteSuite {

--- a/src/test/java/exemplo/jpa/TesteSuite.java
+++ b/src/test/java/exemplo/jpa/TesteSuite.java
@@ -20,6 +20,7 @@ import org.junit.runners.Suite;
     exemplo.jpa.PetNewTeste.class,
     exemplo.jpa.PetSitterNewTeste.class,
     exemplo.jpa.PetOwnerNewTeste.class,
+    exemplo.jpa.NotificacaoTeste.class,
     
 })
 public class TesteSuite {

--- a/src/test/java/exemplo/jpa/stmt.java
+++ b/src/test/java/exemplo/jpa/stmt.java
@@ -1,0 +1,13 @@
+/*
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Classes/Class.java to edit this template
+ */
+package exemplo.jpa;
+
+/**
+ *
+ * @author elaine
+ */
+class stmt {
+    
+}


### PR DESCRIPTION
- Remove JPQL de entidades e testes
- Padroniza remoções via cascade e navegação JPA
- Mantém testes independentes e transacionais
- Nenhuma alteração funcional no domínio